### PR TITLE
Move the database check up closer to the activation, and in particula…

### DIFF
--- a/sam-pro-admin.php
+++ b/sam-pro-admin.php
@@ -53,6 +53,10 @@ if ( class_exists( 'SamProCore' ) && ! class_exists( 'SamProAdmin' ) ) {
 			register_deactivation_hook( SAM_PRO_MAIN_FILE, array( &$this, 'onDeactivate' ) );
 			register_uninstall_hook( SAM_PRO_MAIN_FILE, array( __CLASS__, 'onUninstall' ) );
 
+			include_once('sam-pro-updater.php');
+			$updater = new SamProUpdater($this->samVersions['db'], $options);
+			$updater->check($sam_pro_tables_definition);
+
 			$ea_url = admin_url('admin.php') . '?page=sam-pro-ad-editor';
 			$ep_url = admin_url('admin.php') . '?page=sam-pro-place-editor';
 			if(isset($_SERVER['HTTP_REFERER'])) {
@@ -77,10 +81,6 @@ if ( class_exists( 'SamProCore' ) && ! class_exists( 'SamProAdmin' ) ) {
 
 			add_action('add_meta_boxes', array(&$this, 'addMetaBoxes'));
 			add_action('save_post', array(&$this, 'savePost'));
-
-			include_once('sam-pro-updater.php');
-			$updater = new SamProUpdater($this->samVersions['db'], $options);
-			$updater->check($sam_pro_tables_definition);
 		}
 
 		public function uploadDir( $param ) {
@@ -1352,7 +1352,7 @@ ORDER BY uu.owner;";
 			add_settings_field('dfpPub', __("Google DFP Pub Code (GAM)", SAM_PRO_DOMAIN), array(&$this, 'drawTextOption'), 'sam-pro-settings', 'sam_dfp_section', array('description' => __('Your Google DFP Pub code. i.e:', SAM_PRO_DOMAIN).' ca-pub-0000000000000000. '.__('Only for GAM mode.', SAM_PRO_DOMAIN), 'width' => '200px'));
 			add_settings_field('dfpNetworkCode', __('Google DFP Network Code (GPT)', SAM_PRO_DOMAIN), array(&$this, 'drawTextOption'), 'sam-pro-settings', 'sam_dfp_section', array('description' => __('Network Code of Your DFP Ad Network. Only for GPT mode.', SAM_PRO_DOMAIN), 'width' => '200px'));
 			do_action('sam_pro_settings_fields_dfp_section');
-			
+
 			add_settings_field('adsensePub', __('Google AdSense Pub Code', SAM_PRO_DOMAIN), array(&$this, 'drawTextOption'), 'sam-pro-settings', 'sam_adsense_section', array('description' => __('Your Google AdSense Pub Code.'), 'placeholder' => 'ca-pub-0000000000000000', 'width' => '100%'));
 			add_settings_field('enablePageLevelAds', __("Allow using Google AdSense page-level (<span id='anchor-help'>anchor/overlay</span> or/and <span id='vignette-help'>vignette</span>) ads on mobile devices", SAM_PRO_DOMAIN), array(&$this, 'drawCheckboxOption'), 'sam-pro-settings', 'sam_adsense_section', array('label_for' => 'enablePageLevelAds', 'checkbox' => true, 'description' => __('Do not forget to adjust your Google AdSense settings on settings page (My Ads -> Page-level ads).', SAM_PRO_DOMAIN)));
 
@@ -1592,7 +1592,7 @@ FROM {$pTable} sp WHERE sp.amode = 2;";
 		public function drawDFPSection() {
 			echo '<p>'.__('Adjust parameters of your Google DFP account.', SAM_PRO_DOMAIN).'</p>';
 		}
-		
+
 		public function drawAdsenseSection() {
 			echo "<p></p>";
 		}

--- a/sam-pro-front.php
+++ b/sam-pro-front.php
@@ -471,6 +471,9 @@ GA_googleFetchAds();
 				elseif(is_category()) {
 					$viewPages |= SAM_PRO_IS_CATEGORY;
 					$cat = get_category( get_query_var( 'cat' ), false );
+					if (is_wp_error($cat)) {
+						return;
+					}
 					$zone .= ((!empty($zone)) ? ',' : '') . "category_all-cats,category_{$cat->category_nicename}";
 					if($rules['categories']) {
 						$arc = "IF(sa.ecats, IF(sa.xcats, NOT FIND_IN_SET(\"{$cat->category_nicename}\", sa.cats), FIND_IN_SET(\"{$cat->category_nicename}\", sa.cats)), TRUE)";
@@ -479,6 +482,9 @@ GA_googleFetchAds();
 				elseif(is_tag()) {
 					$viewPages |= SAM_PRO_IS_TAG;
 					$tag = get_tag( get_query_var( 'post_tag_id' ) );
+					if (is_wp_error($tag)) {
+						return;
+					}
 					$zone .= ((!empty($zone)) ? ',' : '') . "post_tag_all-tags,post_tag_{$tag->slug}";
 					if($rules['tags']) {
 						$arc = "IF(sa.etags, IF(sa.xtags, NOT FIND_IN_SET(\"{$tag->slug}\", sa.tags), FIND_IN_SET(\"{$tag->slug}\", sa.tags)), TRUE)";


### PR DESCRIPTION
When activating the plugin it generated over thousand lines of unexpected output, and an error about it. Moving the database check closer to the activation hook, and in particular above the getAdsData method, it omits the error message and everything looks fine.

I'll be honest, without detailed knowledge about the plugin, I can't be sure this is a watertight solution. I'll leave that to you. :)

To reproduce the error, deactivate the plugin and remove the tables specific to sam pro, then activate it again. The problem occurs in sam-pro-admin.php, at the SQL queries in getAdsData.

P.S. I can see my editor (Atom) added a few different blank rows. I didn't change the tabbing or anything, it's probably just something the editor does. Omit them if possible. :)

Update:

I added a commit to handle some WP Errors I came across.
